### PR TITLE
Add data to singular words with no plurals

### DIFF
--- a/pluralize.js
+++ b/pluralize.js
@@ -402,7 +402,6 @@
     // Singular words with no plurals.
     'adulthood',
     'advice',
-    'agenda',
     'aid',
     'aircraft',
     'alcohol',

--- a/pluralize.js
+++ b/pluralize.js
@@ -425,6 +425,7 @@
     'commerce',
     'cooperation',
     'corps',
+    'data',
     'debris',
     'diabetes',
     'digestion',


### PR DESCRIPTION
`pluralize.singular('data')` returns `datum` because of the rule here: https://github.com/plurals/pluralize/blob/master/pluralize.js#L385

This PR just adds data to the list of singular words with no plurals because I don't believe data has a plural form

Closes #145