### PR TITLE
Add preserveCasing option to addIrregularRule

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,6 +73,11 @@ pluralize.plural('irregular') //=> "irregulars"
 pluralize.addIrregularRule('irregular', 'regular')
 pluralize.plural('irregular') //=> "regular"
 
+// Example of new irregular rule preserving casing, e.g. "ID" -> "IDs":
+pluralize.plural('ID') //=> "IDS"
+pluralize.addIrregularRule('ID', 'IDs', { preserveCasing: true })
+pluralize.plural('ID') //=> "IDs"
+
 // Example of uncountable rule (rules without singular/plural in context):
 pluralize.plural('paper') //=> "papers"
 pluralize.addUncountableRule('paper')

--- a/pluralize.js
+++ b/pluralize.js
@@ -132,6 +132,11 @@
    */
   function replaceWord (replaceMap, keepMap, rules) {
     return function (word) {
+      // If replaceMap has the exact casing, we preserve the casing
+      if (replaceMap.hasOwnProperty(word)) {
+        return replaceMap[word];
+      }
+
       // Get the correct token and case restoration functions.
       var token = word.toLowerCase();
 
@@ -257,9 +262,11 @@
    * @param {string} single
    * @param {string} plural
    */
-  pluralize.addIrregularRule = function (single, plural) {
-    plural = plural.toLowerCase();
-    single = single.toLowerCase();
+  pluralize.addIrregularRule = function (single, plural, { preserveCasing = false } = {}) {
+    if (!preserveCasing) {
+      plural = plural.toLowerCase();
+      single = single.toLowerCase();
+    }
 
     irregularSingles[single] = plural;
     irregularPlurals[plural] = single;

--- a/test.js
+++ b/test.js
@@ -801,6 +801,14 @@ describe('pluralize', function () {
       expect(pluralize('irregular')).to.equal('regular');
     });
 
+    it('should allow new irregular words with preserved casing', function () {
+      expect(pluralize('ID')).to.equal('IDS');
+
+      pluralize.addIrregularRule('ID', 'IDs', { preserveCasing: true });
+
+      expect(pluralize('ID')).to.equal('IDs');
+    });
+
     it('should allow new plural matching rules', function () {
       expect(pluralize.plural('regex')).to.equal('regexes');
 


### PR DESCRIPTION
Added a preserveCasing option to addIrregularRule to handle cases where you want to pluralize things like ID => IDs. 